### PR TITLE
Update travis build matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ deps
 *.plt
 ebin/
 rel/bktree/
+.rebar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: erlang
 otp_release:
-    - R15B02
-    - R15B03
+  - 18.3
+  - 19.2


### PR DESCRIPTION
## What

Project got wildly out of date with current OTP releases being used on CI. Update
to use current versions to build against.

## Changes

- Ignore .rebar directory from git
- Update travis build matrix to build against `18.3` and `19.2`